### PR TITLE
use debian:buster-slim as the base image for runtime

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,18 +1,18 @@
-FROM rustlang/rust:nightly as planner
+FROM rustlang/rust:nightly-slim as planner
 WORKDIR app
 RUN cargo install cargo-chef
 COPY . .
 RUN cargo chef prepare --recipe-path recipe.json
 
 
-FROM rustlang/rust:nightly as cacher
+FROM rustlang/rust:nightly-slim as cacher
 WORKDIR app
 RUN cargo install cargo-chef
 COPY --from=planner /app/recipe.json recipe.json
 RUN cargo chef cook --release --recipe-path recipe.json
 
 
-FROM rustlang/rust:nightly as builder
+FROM rustlang/rust:nightly-slim as builder
 WORKDIR app
 COPY . .
 # Copy over the cached dependencies
@@ -21,7 +21,7 @@ COPY --from=cacher /usr/local/cargo /usr/local/cargo
 RUN cargo build --release --bin termpad
 
 
-FROM rustlang/rust:nightly-slim as runtime
+FROM debian:buster-slim as runtime
 WORKDIR app
 COPY --from=builder /app/target/release/termpad /usr/local/bin
 ENTRYPOINT ["/usr/local/bin/termpad"]

--- a/README.md
+++ b/README.md
@@ -46,13 +46,13 @@ $ termpad -d example.com
 ```
 This will return urls like: `http://example.com/BrightAliveMotorcycle`
 
-### Port (`-p` or `--port`)
+### Port (`-p` or `--port`, env = `PORT`)
 Set the port on which the app runs (Default: `8000`)
 ```shell
 $ termpad -p 8043
 ```
 
-### Output (`-o` or `--output`)
+### Output (`-o` or `--output`, env = `OUTPUT`)
 Relative or absolute path to the directory where you want to store user-posted pastes (Default: `~/.local/share/termpad/`)
 ```shell
 $ termpad -o /home/www/pastes/

--- a/src/options.rs
+++ b/src/options.rs
@@ -10,7 +10,8 @@ pub struct Opt {
         short,
         long,
         parse(from_os_str),
-        default_value = "~/.local/share/termpad"
+        default_value = "~/.local/share/termpad",
+        env = "OUTPUT"
     )]
     pub output: PathBuf,
     /// This will be used as to construct the url that is returned to the client.
@@ -21,7 +22,7 @@ pub struct Opt {
     #[structopt(long, env = "HTTPS")]
     pub https: bool,
     /// The port on which the app should run on
-    #[structopt(short, long, default_value = "8000")]
+    #[structopt(short, long, default_value = "8000", env="PORT")]
     pub port: u16,
     /// How many days to keep files for. A value of 0 means forever
     #[structopt(long, default_value = "120", env = "DELETE_AFTER")]


### PR DESCRIPTION
Changes the runtime image to debian:buster-slim as the compiler and toolchain are currently shipped with the image which takes up a lot of space.